### PR TITLE
fix: cummax aliasing, flash_v2 causal configs, chunked pass-2 reductions

### DIFF
--- a/kernels/attention/flash_attention_v2.py
+++ b/kernels/attention/flash_attention_v2.py
@@ -16,11 +16,17 @@ import torch.nn.functional as F
 
 # ── Kernel ────────────────────────────────────────────────────────────────────
 
+# Invariant: BLOCK_N <= BLOCK_M. Loop A processes fully-past K/V tiles with no
+# causal mask, which is only correct when a Loop-A tile cannot straddle the
+# diagonal — i.e. when BLOCK_N <= BLOCK_M. With BLOCK_N > BLOCK_M a Loop-A tile
+# (kv_start in range(0, q_start, BLOCK_N)) can extend past q_start and attend to
+# future keys unmasked, and Loop B (range(q_start, q_start+BLOCK_M, BLOCK_N))
+# then re-processes the overlapping keys — double-counting them. Any config with
+# BLOCK_N > BLOCK_M is therefore unsound and must not appear below.
 @triton.autotune(
     configs=[
         triton.Config({"BLOCK_M": 64, "BLOCK_N": 64}, num_warps=4),
         triton.Config({"BLOCK_M": 64, "BLOCK_N": 32}, num_warps=4),
-        triton.Config({"BLOCK_M": 32, "BLOCK_N": 64}, num_warps=4),
         triton.Config({"BLOCK_M": 32, "BLOCK_N": 32}, num_warps=4),
     ],
     key=["N", "d"],

--- a/kernels/attention/naive_attention.py
+++ b/kernels/attention/naive_attention.py
@@ -67,8 +67,6 @@ def naive_attention_kernel(
     # multiply by V.  Because N fits in registers for small N, we hold the
     # full [BLOCK_N, N] score matrix in registers.
 
-    # Pass 1: accumulate scores and track per-row max (for numerical stability)
-    scores = tl.zeros([BLOCK_N, 1], dtype=tl.float32)  # placeholder shape
     # We can't dynamically size a register array by N at runtime.
     # Instead we loop over K tiles and do online softmax (max + sum tracked).
 
@@ -148,7 +146,8 @@ def naive_attention(
 
     Args:
         q, k, v: Tensors of shape (B, H, N, d), fp32 or fp16.
-                 d must be a power of 2; N must be divisible by BLOCK_N.
+                 d must be a power of 2; N can be any length — the kernel masks
+                 the final partial tile in both the query and key/value loops.
                  N <= 2048 recommended (register pressure).
 
     Returns:

--- a/kernels/reductions/max_min.py
+++ b/kernels/reductions/max_min.py
@@ -55,17 +55,28 @@ def argmax_partials_kernel(
     out_val_ptr,
     out_idx_ptr,
     num_blocks: int,
-    BLOCK_SIZE: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,   # chunk width — capped at CHUNK in the wrapper
 ):
-    offs = tl.arange(0, BLOCK_SIZE)
-    mask = offs < num_blocks
-    vals = tl.load(val_ptr + offs, mask=mask, other=-float("inf"))
-    idxs = tl.load(idx_ptr + offs, mask=mask, other=0)
-    global_max = tl.max(vals, axis=0)
-    # Recover the index: among all blocks whose val equals global_max, take argmax
-    local_idx = tl.argmax(vals, axis=0)
-    tl.store(out_val_ptr, global_max)
-    tl.store(out_idx_ptr, tl.load(idx_ptr + local_idx))
+    # Chunked scan of the per-block (value, index) pairs. tl.arange stays bounded
+    # to BLOCK_SIZE (<= CHUNK) instead of next_power_of_2(num_blocks), so the
+    # register footprint does not scale with num_blocks (the 2**28 resource
+    # exhaustion). Running best value + its absolute stored index carry across
+    # chunks. Strict `>` keeps the earliest chunk's winner on ties, matching the
+    # old single-tile tl.argmax (lowest block index → first occurrence overall).
+    best_val = -float("inf")
+    best_idx = tl.zeros([], dtype=tl.int64)
+    for chunk_start in range(0, num_blocks, BLOCK_SIZE):
+        offs = chunk_start + tl.arange(0, BLOCK_SIZE)
+        mask = offs < num_blocks
+        vals = tl.load(val_ptr + offs, mask=mask, other=-float("inf"))
+        chunk_max = tl.max(vals, axis=0)
+        chunk_pos = tl.argmax(vals, axis=0)                     # position in chunk
+        chunk_idx = tl.load(idx_ptr + chunk_start + chunk_pos)  # absolute index
+        take = chunk_max > best_val
+        best_idx = tl.where(take, chunk_idx, best_idx)
+        best_val = tl.where(take, chunk_max, best_val)
+    tl.store(out_val_ptr, best_val)
+    tl.store(out_idx_ptr, best_idx)
 
 
 @triton.jit
@@ -93,19 +104,33 @@ def argmin_partials_kernel(
     out_val_ptr,
     out_idx_ptr,
     num_blocks: int,
-    BLOCK_SIZE: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,   # chunk width — capped at CHUNK in the wrapper
 ):
-    offs = tl.arange(0, BLOCK_SIZE)
-    mask = offs < num_blocks
-    vals = tl.load(val_ptr + offs, mask=mask, other=float("inf"))
-    idxs = tl.load(idx_ptr + offs, mask=mask, other=0)
-    global_min = tl.min(vals, axis=0)
-    local_idx = tl.argmin(vals, axis=0)
-    tl.store(out_val_ptr, global_min)
-    tl.store(out_idx_ptr, tl.load(idx_ptr + local_idx))
+    # Chunked scan, mirror of argmax_partials_kernel. Running best (min) value +
+    # its absolute stored index carry across chunks; strict `<` keeps the
+    # earliest chunk's winner on ties (first occurrence overall).
+    best_val = float("inf")
+    best_idx = tl.zeros([], dtype=tl.int64)
+    for chunk_start in range(0, num_blocks, BLOCK_SIZE):
+        offs = chunk_start + tl.arange(0, BLOCK_SIZE)
+        mask = offs < num_blocks
+        vals = tl.load(val_ptr + offs, mask=mask, other=float("inf"))
+        chunk_min = tl.min(vals, axis=0)
+        chunk_pos = tl.argmin(vals, axis=0)                     # position in chunk
+        chunk_idx = tl.load(idx_ptr + chunk_start + chunk_pos)  # absolute index
+        take = chunk_min < best_val
+        best_idx = tl.where(take, chunk_idx, best_idx)
+        best_val = tl.where(take, chunk_min, best_val)
+    tl.store(out_val_ptr, best_val)
+    tl.store(out_idx_ptr, best_idx)
 
 
 # ── 2. Python wrappers ────────────────────────────────────────────────────────
+
+# Pass-2 tile cap. 4096 fp32 partials = 16 KB — well within SMEM/registers — and
+# keeps tl.arange bounded so the pass-2 kernel's register footprint does not
+# scale with num_blocks. Beyond CHUNK, the pass-2 chunk loop iterates.
+CHUNK = 4096
 
 def _reduce(val_kernel, part_kernel, x: torch.Tensor, fill: float):
     assert x.is_cuda, "Input must be on CUDA"
@@ -113,7 +138,8 @@ def _reduce(val_kernel, part_kernel, x: torch.Tensor, fill: float):
     n = x.numel()
     BLOCK_SIZE = 1024
     num_blocks = triton.cdiv(n, BLOCK_SIZE)
-    block2 = triton.next_power_of_2(num_blocks)
+    # Cap the pass-2 tile at CHUNK; larger num_blocks is covered by the loop.
+    block2 = min(triton.next_power_of_2(num_blocks), CHUNK)
 
     part_vals = torch.empty(num_blocks, device=x.device, dtype=torch.float32)
     part_idxs = torch.empty(num_blocks, device=x.device, dtype=torch.int64)
@@ -137,7 +163,10 @@ def argmin(x: torch.Tensor):
 # ── 3. Correctness tests ──────────────────────────────────────────────────────
 
 def test_max_min():
-    sizes = [1, 127, 128, 1024, 1025, 65536, 100_000, 1_000_000]
+    # n=2**24 (num_blocks=16384 > CHUNK) exercises the chunked pass-2 loop. The
+    # shipped benchmark reaches n=2**28 — the regression target for the old
+    # single-tile arange resource exhaustion — validated on Colab, not here.
+    sizes = [1, 127, 128, 1024, 1025, 65536, 100_000, 1_000_000, 2**24]
     dtypes = [torch.float32, torch.float16]
 
     for dtype in dtypes:

--- a/kernels/reductions/reduce_sum.py
+++ b/kernels/reductions/reduce_sum.py
@@ -51,15 +51,28 @@ def reduce_partials_kernel(
     partial_ptr,
     out_ptr,
     num_blocks: int,
-    BLOCK_SIZE: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,   # chunk width — capped at CHUNK in the wrapper
 ):
-    offs = tl.arange(0, BLOCK_SIZE)
-    mask = offs < num_blocks
-    x = tl.load(partial_ptr + offs, mask=mask, other=0.0)
-    tl.store(out_ptr, tl.sum(x, axis=0))
+    # Chunked accumulation: tl.arange stays bounded to BLOCK_SIZE (<= CHUNK)
+    # instead of growing to next_power_of_2(num_blocks). At n=2**28 the old
+    # single-tile version needed a 2**18-wide arange → register/resource
+    # exhaustion; here the tile is fixed and the loop runs
+    # tl.cdiv(num_blocks, BLOCK_SIZE) times, keeping register pressure flat.
+    acc = 0.0
+    for chunk_start in range(0, num_blocks, BLOCK_SIZE):
+        offs = chunk_start + tl.arange(0, BLOCK_SIZE)
+        mask = offs < num_blocks
+        x = tl.load(partial_ptr + offs, mask=mask, other=0.0)
+        acc += tl.sum(x, axis=0)
+    tl.store(out_ptr, acc)
 
 
 # ── 2. Python wrapper ─────────────────────────────────────────────────────────
+
+# Pass-2 tile cap. 4096 fp32 partials = 16 KB — well within SMEM/registers —
+# and keeps tl.arange bounded so the pass-2 kernel's register footprint does not
+# scale with num_blocks. Anything larger is handled by the pass-2 chunk loop.
+CHUNK = 4096
 
 def reduce_sum(x: torch.Tensor) -> torch.Tensor:
     assert x.is_cuda, "Input must be on CUDA"
@@ -72,9 +85,9 @@ def reduce_sum(x: torch.Tensor) -> torch.Tensor:
     partials = torch.empty(num_blocks, device=x.device, dtype=torch.float32)
     reduce_sum_kernel[(num_blocks,)](x, partials, n, BLOCK_SIZE=BLOCK_SIZE)
 
-    # Pass 2: sum the partials in a single block.
-    # next_power_of_2 gives a valid tl.constexpr that covers all partials.
-    block2 = triton.next_power_of_2(num_blocks)
+    # Pass 2: sum the partials in a single program, chunked. The tile is capped
+    # at CHUNK; num_blocks beyond that is covered by the in-kernel chunk loop.
+    block2 = min(triton.next_power_of_2(num_blocks), CHUNK)
     out = torch.empty(1, device=x.device, dtype=torch.float32)
     reduce_partials_kernel[(1,)](partials, out, num_blocks, BLOCK_SIZE=block2)
 
@@ -84,7 +97,10 @@ def reduce_sum(x: torch.Tensor) -> torch.Tensor:
 # ── 3. Correctness tests ──────────────────────────────────────────────────────
 
 def test_reduce_sum():
-    sizes = [1, 127, 128, 1024, 1025, 65536, 100_000, 1_000_000]
+    # n=2**24 (num_blocks=16384 > CHUNK) exercises the chunked pass-2 loop. The
+    # shipped benchmark reaches n=2**28 — the regression target for the old
+    # single-tile arange resource exhaustion — validated on Colab, not here.
+    sizes = [1, 127, 128, 1024, 1025, 65536, 100_000, 1_000_000, 2**24]
     dtypes = [torch.float32, torch.float16]
 
     for dtype in dtypes:

--- a/kernels/scanning/cummax.py
+++ b/kernels/scanning/cummax.py
@@ -107,7 +107,12 @@ def cummax(x: torch.Tensor) -> torch.Tensor:
     n = x.numel()
     num_blocks = triton.cdiv(n, BLOCK_SIZE)
 
-    out = x.to(torch.float32)
+    # copy=True is required: pass 1 and pass 3 scan in-place over `out`. Plain
+    # x.to(torch.float32) is a no-op alias when x is already fp32 (torch
+    # semantics), which would overwrite the caller's tensor and return an alias
+    # of it. copy=True always allocates a fresh buffer (fp16 input already
+    # copies during the cast, so this adds no second copy there).
+    out = x.to(torch.float32, copy=True)
     block_maxes = torch.empty(num_blocks, device=x.device, dtype=torch.float32)
 
     cummax_pass1[(num_blocks,)](out, out, block_maxes, n, BLOCK_SIZE=BLOCK_SIZE)
@@ -130,9 +135,15 @@ def test_cummax():
     ]
     for n in sizes:
         x = torch.randn(n, device="cuda", dtype=torch.float32)
+        x_before = x.clone()                 # snapshot to prove the input is untouched
         ref = torch.cummax(x, dim=0).values
         got = cummax(x)
         torch.testing.assert_close(got, ref, rtol=1e-5, atol=1e-5)
+
+        # Regression guard for the input-aliasing bug: the result must be a
+        # fresh allocation and the caller's tensor must be bit-identical after.
+        assert got.data_ptr() != x.data_ptr(), "cummax returned an alias of its input"
+        torch.testing.assert_close(x, x_before, rtol=0, atol=0)
 
     print("test_cummax: PASSED")
 

--- a/kernels/scanning/prefix_sum.py
+++ b/kernels/scanning/prefix_sum.py
@@ -167,6 +167,10 @@ def prefix_sum(x: torch.Tensor) -> torch.Tensor:
     inclusive = torch.empty(num_blocks, device=x.device, dtype=torch.float32)
     counter  = torch.zeros(1,          device=x.device, dtype=torch.int32)
 
+    # x.float() aliases x when x is already fp32 (torch semantics), but that is
+    # safe here: the kernel only reads this operand — it never writes back into
+    # it (output goes to the separate `out` buffer). cummax needs copy=True
+    # because its passes scan in-place.
     prefix_sum_dlb_kernel[(num_blocks,)](
         x.float(), out,
         flags, partial, inclusive, counter,


### PR DESCRIPTION
First Phase-1 feature (OVERHAUL_PLAN): correctness fixes found by the 2026-08-11 line-by-line audit.

- **cummax** returned an alias of its fp32 input and scanned it in place (`x.to(torch.float32)` is a no-op alias); now `copy=True` + regression test asserting fresh allocation and unchanged input
- **flash_attention_v2**: removed the `BLOCK_M=32, BLOCK_N=64` autotune config — Loop A applies no causal mask, which is only sound when BLOCK_N ≤ BLOCK_M; invariant documented above the config list
- **reduce_sum / max_min**: pass 2 was a single program with `tl.arange(0, next_power_of_2(num_blocks))` — resource exhaustion at the benchmark-reachable n=2²⁸; now a chunked loop over CHUNK=4096 tiles with running best value+index (first-occurrence ties preserved)
- **naive_attention**: dead `scores` array removed; docstring divisibility claim corrected

**Pending L4 validation** — no GPU available locally; `py_compile` clean. Affected tests: test_scanning, test_reductions, test_attention (run on Colab before phase→main).